### PR TITLE
Changing to vw, vh as stated by google for embeds

### DIFF
--- a/facebook_event_button.html
+++ b/facebook_event_button.html
@@ -9,7 +9,7 @@
     border-size: 2px;
     border-radius: 5px;
     background-color: #FFFFFF;
-    width: 80%; height: 60px;
+    width: 80vw; height: 80vh;
   }
   a{
     font-family: 'Chelsea Market', cursive;  


### PR DESCRIPTION
Embeds will not size properly unless you use vw vh instead of % or px as it is an iframe embed base on the size defined in google sites (We can use media queries and vw vh of the iframe to better fix the scrolling issues.)